### PR TITLE
Fix Ubuntu resize gap in floating panels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.dockfx</groupId>
     <artifactId>DockFX</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.8</version>
+    <version>0.1.9</version>
     <name>DockFX</name>
     <url>https://github.com/ClearControl/DockFX.git</url>
 

--- a/src/main/resources/org/dockfx/default.css
+++ b/src/main/resources/org/dockfx/default.css
@@ -111,8 +111,8 @@
 
 .dock-node-border {
   -fx-padding: 5;
-  -fx-background-color: LightGray;
-  -fx-effect: dropshadow( three-pass-box, rgba(0,0,0,0.4), 10,0.2,0,0 );
+  -fx-background-color: transparent;
+  -fx-effect: dropshadow( three-pass-box, rgba(10,10,10,0.3), 120,0.2,0,0 );
 }
 
 .dock-node-border:maximized {

--- a/src/main/resources/org/dockfx/default.css
+++ b/src/main/resources/org/dockfx/default.css
@@ -110,8 +110,8 @@
  ******************************************************************************/
 
 .dock-node-border {
-  -fx-padding: 10;
-  -fx-background-color: transparent;
+  -fx-padding: 5;
+  -fx-background-color: LightGray;
   -fx-effect: dropshadow( three-pass-box, rgba(0,0,0,0.4), 10,0.2,0,0 );
 }
 


### PR DESCRIPTION
This is fixed on the head of ClearControl/DockFX but there's a significant amount of conflicts when merging. Without knowing the changes on this fork I think it's easier for me to fix this myself.

Feel free to merge ClearControl/DockFX if you're confident of merging it and scrap this PR.